### PR TITLE
Link to .org not .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SVG Spritemap
 
-**SVG Spritemap** is a [WordPress](//wordpress.com) plugin that lets you add SVGs with the Media Uploader, as well as create and manage an SVG spritemap from your Media Library.
+**SVG Spritemap** is a [WordPress](//wordpress.org) plugin that lets you add SVGs with the Media Uploader, as well as create and manage an SVG spritemap from your Media Library.
 
 ![Screenshot](http://i.imgur.com/hx84168.png)


### PR DESCRIPTION
Hi there. Just spotted that the link in the readme was to WordPress.com not .org
