### PR TITLE
Updates wordpress link to point to .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SVG Spritemap
 
-**SVG Spritemap** is a [WordPress](//wordpress.com) plugin that lets you add SVGs with the Media Uploader, as well as create and manage an SVG spritemap from your Media Library.
+**SVG Spritemap** is a [WordPress](//wordpress.org) plugin that lets you add SVGs with the Media Uploader, as well as create and manage an SVG spritemap from your Media Library.
 
 ![Screenshot](http://i.imgur.com/hx84168.png)


### PR DESCRIPTION
This is awesome and I am excited to dig into it more. I updated the wordpress link in the readme to point to wordpress.org rather than wordpress.com to avoid confusion. This plugin if for self hosted wordpress installs rather than wordpress.com accounts so if figured the wordpress link should reflect that. 
