### PR TITLE
[svgmap] shortcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+defs.svg
+
+defs.json

--- a/README.md
+++ b/README.md
@@ -10,12 +10,34 @@
 
 After selecting and updating the SVGs for your spritemap, a combined `defs.svg` SVG spritemap is automatically generated.
 
+## Using Icons
+
 A text field displays the URL to the SVG spritemap. Individuals sprites may be referenced by appending `#:` and the name of the sprite to the URL.
 
 ```html
 <svg><use xlink:href="http://dev.wordpress/wp-content/plugins/svg-spritemap/defs.svg#:accounts"></svg>
 ```
 
+## Shortcode
+
+Simplify including icons within Wordpress by using the `[svgmap]` shortcode in the editors. Set the required `sprite` attribute and an `<svg>` tag will be inserted in your page/post with the desired SVG image. All other shortcode parameters will be added to the inserted `<svg>` as attributes, allowing you to set `class`, `fill`, `width`, `height` and more.
+
+**Shortcode**
+```html
+[svgmap sprite="accounts" width="100" height="100" fill="#F00" class="icon"]
+```
+
+**Output:**
+```html
+<svg width="100" height="100" fill="#F00" class="icon"><use xlink:href="http://dev.wordpress/wp-content/plugins/svg-spritemap/defs.svg#:accounts"></svg>
+```
+
+*Note: To change the `fill` or `stroke` of your SVG, do not include those attributes in the uploaded SVG. The included SVG's attributes override anything set on the `<use>` or `<svg>`.*
+
+## Filesize
+
 The live, estimated filesize of the spritemap represents the combined filesize of all the individual SVGs, but it does not factor in additional gzip compression. More than likely, the estimation will be conservative and the filesize will actually be smaller than the estimation.
+
+## Browser Support
 
 Internet Explorer requires special assistance to display external SVGs. To resolve this issue, I have developed [SVG4Everybody](https://github.com/jonathantneal/svg4everybody).

--- a/inc/svgmap_media_page.post.inc
+++ b/inc/svgmap_media_page.post.inc
@@ -1,29 +1,39 @@
 <?php
 
-$svg_string = '<svg xmlns="http://www.w3.org/2000/svg">';
-$id_array = array();
+if ( wp_verify_nonce($_REQUEST['_wpnonce'], 'svgmap_submit') ) {
 
-foreach ($_POST as $id => $name) {
-	array_push($id_array, $id);
+	$svg_string = '<svg xmlns="http://www.w3.org/2000/svg">';
+	$id_array = array();
 
-	$url = wp_get_attachment_image_src($id);
+	foreach ($_POST as $id => $name) {
+		if ( is_numeric($id) ) {
+			$url = wp_get_attachment_image_src($id);
 
-	$path = str_replace($wp_upload_dir['baseurl'], $wp_upload_dir['basedir'], $url[0]);
+			if ( $url ) {
+				$path = str_replace($wp_upload_dir['baseurl'], $wp_upload_dir['basedir'], $url[0]);
 
-	$svg = simplexml_load_file($path);
+				$svg = simplexml_load_file($path);
 
-	$viewbox = $svg->attributes()->viewBox;
+				if ( $svg ) {
+					array_push($id_array, $id);
 
-	$svg_string .= '<symbol viewBox="'.$viewbox.'" id=":'.$name.'">';
+          $viewbox = $svg->attributes()->viewBox;
 
-	foreach ($svg->children() as $child) {
-		$svg_string .= $child->asXML();
+					$svg_string .= PHP_EOL . '<symbol id=":'.$name.'" viewBox="' . $viewbox . '">';
+
+					foreach ($svg->children() as $child) {
+						$svg_string .= preg_replace('/(\t|\n)+/',' ',$child->asXML());
+					}
+
+					$svg_string .= '</symbol>';
+				}
+			}
+		}
 	}
 
-	$svg_string .= '</symbol>';
+	$svg_string .= PHP_EOL . '</svg>';
+
+	file_put_contents($svgmap->svg_path, $svg_string);
+	file_put_contents($svgmap->ids_path, json_encode($id_array));
+
 }
-
-$svg_string .= '</svg>';
-
-file_put_contents($svgmap->svg_path, $svg_string);
-file_put_contents($svgmap->ids_path, json_encode($id_array));

--- a/inc/svgmap_media_page.post.inc
+++ b/inc/svgmap_media_page.post.inc
@@ -2,7 +2,7 @@
 
 if ( wp_verify_nonce($_REQUEST['_wpnonce'], 'svgmap_submit') ) {
 
-	$svg_string = '<svg xmlns="http://www.w3.org/2000/svg">';
+	$svg_string = '<svg xmlns="http://www.w3.org/2000/svg">' . PHP_EOL;
 	$id_array = array();
 
 	foreach ($_POST as $id => $name) {
@@ -19,19 +19,19 @@ if ( wp_verify_nonce($_REQUEST['_wpnonce'], 'svgmap_submit') ) {
 
           $viewbox = $svg->attributes()->viewBox;
 
-					$svg_string .= PHP_EOL . '<symbol id=":'.$name.'" viewBox="' . $viewbox . '">';
+					$svg_string .= '<symbol id=":'.$name.'" viewBox="' . $viewbox . '">';
 
 					foreach ($svg->children() as $child) {
 						$svg_string .= preg_replace('/(\t|\n)+/',' ',$child->asXML());
 					}
 
-					$svg_string .= '</symbol>';
+					$svg_string .= '</symbol>' . PHP_EOL;
 				}
 			}
 		}
 	}
 
-	$svg_string .= PHP_EOL . '</svg>';
+	$svg_string .= '</svg>';
 
 	file_put_contents($svgmap->svg_path, $svg_string);
 	file_put_contents($svgmap->ids_path, json_encode($id_array));

--- a/inc/svgmap_media_page.show.inc
+++ b/inc/svgmap_media_page.show.inc
@@ -32,12 +32,20 @@
 			<p class="svg-panelitem">
 				<span>Estimated filesize: <strong class="svg-filesize">Unknown</strong></span>
 
-        <?php wp_nonce_field('svgmap_submit'); ?>
+				<?php wp_nonce_field('svgmap_submit'); ?>
 				<button class="svg-submit button button-primary" type="submit">Update <?php print $svgmap->name; ?></button>
 			</p>
 		</div>
 	</form>
 </div>
+
+<form action="options.php" method="post">
+<?php
+	settings_fields( $svgmap->id );
+	do_settings_sections( $svgmap->id );
+	submit_button();
+?>
+</form>
 
 <style><?php include $svgmap->path.'/style.css'; ?></style>
 <script><?php include $svgmap->path.'/script.js'; ?></script>

--- a/inc/svgmap_media_page.show.inc
+++ b/inc/svgmap_media_page.show.inc
@@ -32,6 +32,7 @@
 			<p class="svg-panelitem">
 				<span>Estimated filesize: <strong class="svg-filesize">Unknown</strong></span>
 
+        <?php wp_nonce_field('svgmap_submit'); ?>
 				<button class="svg-submit button button-primary" type="submit">Update <?php print $svgmap->name; ?></button>
 			</p>
 		</div>

--- a/inc/svgmap_shortcode.inc
+++ b/inc/svgmap_shortcode.inc
@@ -1,0 +1,22 @@
+<?php
+
+add_shortcode( 'svgmap', 'svgmap_shortcode' );
+function svgmap_shortcode($args) {
+
+	global $svgmap;
+
+	$sprite = $args['sprite'];
+	unset($args['sprite']);
+
+	if ( $sprite ) {
+		$attr = "";
+
+		foreach($args as $key => $value) {
+			$attr .= ' ' . $key . '="' . esc_attr($value) . '"';
+		}
+
+		return '<svg' . $attr .'><use xlink:href="' . esc_url($svgmap->svg_url . '#:'. $sprite) . '"></svg>';
+	} else {
+		return false;
+	}
+}

--- a/inc/svgmap_shortcode.inc
+++ b/inc/svgmap_shortcode.inc
@@ -1,22 +1,43 @@
 <?php
 
-add_shortcode( 'svgmap', 'svgmap_shortcode' );
+global $default_attributes;
+
+$default_attributes = array();
+
+if ( !empty($svgmap->settings['default_attributes']) ) {
+	$def = new SimpleXMLElement('<svg ' . $svgmap->settings['default_attributes'] . ' />');
+
+	foreach ( $def->attributes() as $key => $value ) {
+		$default_attributes[(string) $key] = (string) $value;
+	}
+}
+
+add_shortcode( $svgmap->id, 'svgmap_shortcode' );
 function svgmap_shortcode($args) {
 
 	global $svgmap;
+	global $default_attributes;
 
 	$sprite = $args['sprite'];
-	unset($args['sprite']);
 
 	if ( $sprite ) {
 		$attr = "";
 
-		foreach($args as $key => $value) {
+		$attributes = array_merge($default_attributes, $args);
+		unset($attributes['sprite']);
+
+		if ( $svgmap->settings['add_default_classes'] ) {
+			$attributes['class'] = trim($attributes['class'] . ' svgmap svgmap--' . $sprite);
+		}
+
+		foreach($attributes as $key => $value) {
 			$attr .= ' ' . $key . '="' . esc_attr($value) . '"';
 		}
 
-		return '<svg' . $attr .'><use xlink:href="' . esc_url($svgmap->svg_url . '#:'. $sprite) . '"></svg>';
+		return '<svg' . $attr . '><use xlink:href="' . esc_url($svgmap->svg_url . '#:'. $sprite) . '"></svg>';
 	} else {
 		return false;
 	}
 }
+
+include 'svgmap_shortcode.settings.inc';

--- a/inc/svgmap_shortcode.settings.inc
+++ b/inc/svgmap_shortcode.settings.inc
@@ -1,0 +1,50 @@
+<?php
+
+add_action( 'admin_init', 'svgmap_shortcode_init' );
+function svgmap_shortcode_init() {
+	global $svgmap;
+	add_settings_section(
+		'svgmap_settings_shortcode',
+		__( 'Shortcode Settings', $svgmap->id ),
+		'svgmap_settings_shortcode_description',
+		$svgmap->id
+	);
+
+	add_settings_field(
+		'default_attributes',
+		__( 'Default Attributes', $svgmap->id ),
+		'svgmap_settings_shortcode_attributes',
+		$svgmap->id,
+		'svgmap_settings_shortcode',
+		array( 'label_for' => 'svgmap[default_attributes]' )
+	);
+
+	add_settings_field(
+		'add_default_classes',
+		__( 'Add Default Classes', $svgmap->id ),
+		'svgmap_settings_shortcode_classes',
+		$svgmap->id,
+		'svgmap_settings_shortcode',
+		array( 'label_for' => 'svgmap[add_default_classes]' )
+	);
+}
+
+function svgmap_settings_shortcode_description() { ?>
+	<p>SVG Sprites can be embedded in posts and pages using the <code>[svgicon sprite="&hellip;"]</code> shortcode. The <code>sprite</code> attribute is required to tell the shortcode which SVG to include. Additional attributes on the shortcode are passed to the inserted <code>&lt;svg&gt;</code> element, allowing you to set the <code>width</code>, <code>height</code>, <code>fill</code> and other attributes.</p>
+<?php
+}
+
+function svgmap_settings_shortcode_attributes() {
+	global $svgmap; ?>
+	<code>&lt;svg </code><input type="text" id='svgmap[default_attributes]' name='svgmap[default_attributes]' placeholder='width="100" height="100" class="icon" fill="#000"...' value="<?php echo esc_attr($svgmap->settings['default_attributes']); ?>" style="width: 25em; max-width: 100%;"/><code>&gt;&lt;use xlink:href="&hellip;" /&gt;&lt;/svg&gt;</code>
+	<p class="description">Attributes given to all shortcode SVGs. These may be overridden by shortcode attributes.</p>
+	<?php
+}
+
+function svgmap_settings_shortcode_classes() {
+	global $svgmap; ?>
+	<input type='checkbox' id='svgmap[add_default_classes]' name='svgmap[add_default_classes]' value='1' <?php checked( $svgmap->settings['add_default_classes'], 1 ); ?>>
+	<p class="description">Automatically add the default classes (<code>.svgmap</code> &amp; <code>.svgmap--<b>spritename</b></code>) to all shortcode SVGs, in addition to any classes added via default attributes or shortcode attributes.</p>
+	<?php
+}
+

--- a/index.php
+++ b/index.php
@@ -2,11 +2,11 @@
 Plugin Name: SVG Spritemap Manager
 Plugin URI: http://github.com/jonathantneal/wp-svg-store
 Description: Easily create and manage your SVG spritemap in Wordpress
-Version: 0.1
+Version: 0.2
 Author: Jonathan Neal
 Author URI: http://jonathantneal.com
 Min WP Version: 2.0
-Max WP Version: 3.9
+Max WP Version: 4.1
 License: Public Domain - https://creativecommons.org/publicdomain/zero/1.0/
 */
 

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 Plugin Name: SVG Spritemap Manager
 Plugin URI: http://github.com/jonathantneal/wp-svg-store
 Description: Easily create and manage your SVG spritemap in Wordpress
-Version: 0.2
+Version: 0.3
 Author: Jonathan Neal
 Author URI: http://jonathantneal.com
 Min WP Version: 2.0
@@ -18,14 +18,21 @@ $svgmap = (object) array(
 	'path' => dirname(__FILE__),
 	'permissions' => 'upload_files',
 	'name' => 'SVG Spritemap',
-	'id'   => 'svgmap',
+	'id'   => 'svgmap'
 );
-
 $svgmap->svg_path = $svgmap->path.'/defs.svg';
 $svgmap->ids_path = $svgmap->path.'/defs.json';
 
 $svgmap->svg_url = plugins_url('defs.svg', __FILE__);
 $svgmap->ids_url = plugins_url('defs.json', __FILE__);
+
+$svgmap->settings = get_option( $svgmap->id );
+add_action( 'admin_init', 'svgmap_init' );
+function svgmap_init() {
+	global $svgmap;
+	register_setting( $svgmap->id, $svgmap->id );
+}
+add_option($svgmap->id, array('add_default_classes'=>1));
 
 include 'inc/svgmap_admin_head.inc';
 include 'inc/svgmap_admin_menu.inc';

--- a/index.php
+++ b/index.php
@@ -31,9 +31,9 @@ include 'inc/svgmap_admin_head.inc';
 include 'inc/svgmap_admin_menu.inc';
 include 'inc/svgmap_media_page.inc';
 include 'inc/svgmap_upload_mimes.inc';
+include 'inc/svgmap_shortcode.inc';
 
 add_action('admin_head', 'svgmap_admin_head');
 add_action('admin_menu', 'svgmap_admin_menu');
-add_action('pre_post_update','svgmap_pre_post_update');
 
 add_filter('upload_mimes', 'svgmap_upload_mimes');

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,8 @@ Internet Explorer requires special assistance to display external SVGs. To resol
 
 == Changelog ==
 
+= 0.3 =
+* Added shortcode settings
 = 0.2 =
 * Added [svgmap] shortcode
 = 0.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jonathantneal
 Donate link: http://jonathantneal.com/
 Tags: images, map, media, sprite, spritemap, svg
 Requires at least: 3.0.1
-Tested up to: 3.9
+Tested up to: 4.1
 Stable tag: "trunk"
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -30,6 +30,10 @@ A text field displays the URL to the SVG spritemap. Individuals sprites may be r
 
 	<svg><use xlink:href="http://dev.wordpress/wp-content/plugins/svg-spritemap/defs.svg#:accounts"></svg>
 
+Simplify including icons within Wordpress by using the `[svgmap]` shortcode in the editors. Set the required `sprite` attribute and an `<svg>` tag will be inserted in your page/post with the desired SVG image. All other shortcode parameters will be added to the inserted `<svg>` as attributes, allowing you to set `class`, `fill`, `width`, `height` and more.
+
+  [svgmap sprite="accounts" width="100" height="100" fill="#F00" class="icon"]
+
 = How accurate is the estimated filesize? =
 
 The live, estimated filesize of the spritemap represents the combined filesize of all the individual SVGs, but it does not factor in additional gzip compression. More than likely, the estimation will be conservative and the filesize will actually be smaller than the estimation.
@@ -44,6 +48,8 @@ Internet Explorer requires special assistance to display external SVGs. To resol
 
 == Changelog ==
 
+= 0.2 =
+* Added [svgmap] shortcode
 = 0.1 =
 * Initial release.
 


### PR DESCRIPTION
Simplify including icons within Wordpress by using the `[svgmap]` shortcode in the editors. Set the required `sprite` attribute and an `<svg>` tag will be inserted in your page/post with the desired SVG image. All other shortcode parameters will be added to the inserted `<svg>` as attributes, allowing you to set `class`, `fill`, `width`, `height` and more.