### PR TITLE
Sprite reference names

### DIFF
--- a/inc/svgmap_media_page.show.inc
+++ b/inc/svgmap_media_page.show.inc
@@ -29,7 +29,7 @@
 			<input class="svg-checkbox" type="checkbox" name="<?php print $post->ID; ?>" value="<?php print $name; ?>"<?php print $checked; ?> data-size="<?php print $post->size; ?>">
 			<span class="svg-details">
 				<img class="svg-image" src="<?php print $post->guid; ?>">
-				<span class="svg-name"><?php print $name; ?></span>
+				<span class="svg-name"><?php print $name; ?> <a href="<?php echo get_edit_post_link($post->ID); ?>" target="_blank" class="button button-small">Edit</a></span>
 			</span>
 		</label>
 		<?php } ?>

--- a/inc/svgmap_media_page.show.inc
+++ b/inc/svgmap_media_page.show.inc
@@ -10,14 +10,26 @@
 
 	<form class="svg-list" method="post">
 		<?php
+
+		$names = array();
+
 		foreach ($wp_query_posts as $post) {
 			$checked = in_array($post->ID, $id_array) ? ' checked' : '';
+			$name = sanitize_title($post->post_title);
+
+			if ( isset($names[$name]) ):
+				$names[$name]++;
+				$name = $name . '-' . $names[$name];
+			else:
+				$names[$name] = 1;
+			endif;
+
 		?>
 		<label class="svg-listitem">
-			<input class="svg-checkbox" type="checkbox" name="<?php print $post->ID; ?>" value="<?php print $post->post_name; ?>"<?php print $checked; ?> data-size="<?php print $post->size; ?>">
+			<input class="svg-checkbox" type="checkbox" name="<?php print $post->ID; ?>" value="<?php print $name; ?>"<?php print $checked; ?> data-size="<?php print $post->size; ?>">
 			<span class="svg-details">
 				<img class="svg-image" src="<?php print $post->guid; ?>">
-				<span class="svg-name"><?php print $post->post_name; ?></span>
+				<span class="svg-name"><?php print $name; ?></span>
 			</span>
 		</label>
 		<?php } ?>

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 Plugin Name: SVG Spritemap Manager
 Plugin URI: http://github.com/jonathantneal/wp-svg-store
 Description: Easily create and manage your SVG spritemap in Wordpress
-Version: 0.3
+Version: 0.4
 Author: Jonathan Neal
 Author URI: http://jonathantneal.com
 Min WP Version: 2.0

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,8 @@ Internet Explorer requires special assistance to display external SVGs. To resol
 
 == Changelog ==
 
+= 0.4 =
+* Uses sanitized post_title instead of post_name for sprite references to allow for easy editing
 = 0.3 =
 * Added shortcode settings
 = 0.2 =

--- a/style.css
+++ b/style.css
@@ -41,6 +41,7 @@
 .svg-image {
 	margin: 1em;
 	max-height: 5rem;
+	max-width: 100%;
 	max-width: calc(100% - 2em);
 }
 
@@ -48,10 +49,20 @@
 	background-color: rgba(255,255,255,.65);
 	color: #000;
 	display: block;
-	padding: 0.5em 1em;
+	padding: 0.5em;
+	font-size: 0.9em;
 	text-decoration: none;
 	transition: background-color .1s ease-in-out;
 	white-space: nowrap;
+	overflow: hidden;
+}
+
+.svg-name .button.button-small {
+  font-size: 0.8em;
+  padding: 0.2em 0.2em;
+  height: auto;
+  line-height: 1;
+  float: right;
 }
 
 .svg-checkbox:checked ~ .svg-details {


### PR DESCRIPTION
Uploading SVGs with names of existing files makes the `$post->post_name` enumerated, which is probably not the expected result when you want to reference that sprite. For example, you upload `logo.svg`, but there's already a `logo.jpg`, so currently you have to use `logo-2` to reference `logo.svg`'s sprite.

My solution uses a sanitized `$post->post_title`, which defaults to the filename on upload but can be edited by the user if they choose (`logo` to `logo-red` or `logo-horizontal`). Duplicate names within the sprite sheet are enumerated (`logo` and `logo-2`) as necessary.

For existing users, this may cause slight compatibility issues where the `post_title` may be different than the file name, or where they were already referencing the enumerated `post_name`, but this should be a more elegant solution overall.

I've also added a convenient 'Edit' button that will bring up the file's edit page to change the title or delete unneeded SVGs.
